### PR TITLE
Revert "bug fix obsidian wall on servers without graphic cards installed"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,10 @@ COPY ./entry.sh ${HOMEDIR}/entry.sh
 COPY ./launch.sh ${HOMEDIR}/launch.sh
 
 # Install Core Keeper server dependencies and clean up
-# lib32gcc1 <- fixes tile generation bug (obsidian wall around spawn) without graphic cards mounted to server
-# Thanks to https://www.reddit.com/r/CoreKeeperGame/comments/uym86p/comment/iays04w/?utm_source=share&utm_medium=web2x&context=3
 RUN set -x \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends --no-install-suggests \
-	xvfb mesa-utils lib32gcc1 \
+	xvfb mesa-utils \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	&& mkdir -p "${STEAMAPPDATADIR}" \
 	&& chmod +x "${HOMEDIR}/entry.sh" \


### PR DESCRIPTION
Reverts arguser/core-keeper-dedicated#2

It doesn't compile, should have checked before merge. 

OTOH the package is already included on the base image (steamcmd).
> Package lib32gcc1 is not available, but is referred to by another package.
> This may mean that the package is missing, has been obsoleted, or
> is only available from another source
> However the following packages replace it:
>   lib32gcc-s1